### PR TITLE
remove use of dapper for go generate in release script

### DIFF
--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -82,12 +82,7 @@ fi
 
 yq --inplace ".remoteDialerProxyVersion = \"${NEW_CHART_VERSION}+up${NEW_REMOTEDIALER_VERSION_SHORT}\"" ./build.yaml
 
-# Downloads dapper
-make .dapper
-
-# DAPPER_MODE=bind will make sure we output everything that changed
-DAPPER_MODE=bind ./.dapper go generate ./... || true
-DAPPER_MODE=bind ./.dapper rm -rf go .config
+go generate ./...
 
 git add .
 git commit -m "Bump remotedialer to ${NEW_CHART_VERSION}+up${NEW_REMOTEDIALER_VERSION_SHORT}"


### PR DESCRIPTION
We used to need dapper to be able to run go generate ./... in the release action of rancher/rancher. This was to make sure we install the same dependencies (controller-gen) as the one used for r/r. With https://github.com/rancher/rancher/pull/51153, this is no longer needed, we can just run go generate ./... and go tools will install the tool at the appropriate version.