### PR TITLE
[main] Add release/v0.4 and release/v0.5 branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,9 @@
   "baseBranchPatterns": [
     "main",
     "release/v0.7",
-    "release/v0.6"
+    "release/v0.6",
+    "release/v0.5",
+    "release/v0.4"
   ],
   "prHourlyLimit": 2,
   "enabledManagers": [

--- a/VERSION.md
+++ b/VERSION.md
@@ -5,3 +5,5 @@ Rancher's remotedialer-proxy follows a pre-release (v0.x) strategy of semver. Th
 | main | v0.8 | v2.15 |
 | release/v0.7 | v0.7 | v2.14 |
 | release/v0.6 | v0.6 | v2.13 |
+| release/v0.5 | v0.5 | v2.12 |
+| release/v0.4 | v0.4 | v2.11 |


### PR DESCRIPTION
## Summary

Adds VERSION.md entries and Renovate configuration for new release/v0.4 and release/v0.5 branches.

- release/v0.4 → remotedialer-proxy v0.4.x (Rancher v2.11)
- release/v0.5 → remotedialer-proxy v0.5.x (Rancher v2.12)

These branches are being created to backport Go 1.25.11 for stdlib CVE remediation.

## Changes

- `.github/renovate.json`: Add release/v0.4 and release/v0.5 to baseBranchPatterns
- `VERSION.md`: Add rows for v0.4 → v2.11 and v0.5 → v2.12