### PR TITLE
[release/v0.7] Bump build base

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM rancher/hardened-build-base:v1.25.10b1@sha256:92ecda122083602ae6e698244dbc91e7108a37d636486325e00940d8e98ab858 AS builder
+FROM rancher/hardened-build-base:v1.25.11b1@sha256:3e20264111abe175898f6fe502eadf56abd61222fcb1ac348539b3f106c4dcb4 AS builder
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
- `Dockerfile.proxy`: Use hardened-build-base:v1.25.11b1@sha256:3e20264111abe175898f6fe502eadf56abd61222fcb1ac348539b3f106c4dcb4

