### PR TITLE
[main] Bump hardened-build-base

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM rancher/hardened-build-base:v1.26.3b1@sha256:2b8bbd35ac1af839ff3b594d9611d6b68fc5843178a5c6a4164882ac6c186f3b AS builder
+FROM rancher/hardened-build-base:v1.26.4b1@sha256:82b0ded3f892de5eacc070500456c8002f544083a91648b55233822fbd64ff6a AS builder
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
- `Dockerfile.proxy`: Use hardened-build-base:v1.26.4b1@sha256:82b0ded3f892de5eacc070500456c8002f544083a91648b55233822fbd64ff6a
