### PR TITLE
[release/v0.6] Bump Go to 1.26.5

### DIFF
--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM rancher/hardened-build-base:v1.26.4b1@sha256:82b0ded3f892de5eacc070500456c8002f544083a91648b55233822fbd64ff6a AS builder
+FROM rancher/hardened-build-base:v1.26.5b1@sha256:4eeb324b5359ed1447a9ed2e0730cadf098d49e97cac5ab1e278685b67c5a602 AS builder
 WORKDIR /app
 
 COPY . .


### PR DESCRIPTION
Bump hardened-build-base image to v1.26.5b1 in Dockerfile.proxy.