### PR TITLE
Branch out release/v0.8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
   ],
   "baseBranchPatterns": [
     "main",
+    "release/v0.8",
     "release/v0.7",
     "release/v0.6",
     "release/v0.5",

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -5,7 +5,7 @@ on:
       charts_ref:
         description: "Submit PR against the following rancher/charts branch (eg: dev-v2.15)"
         required: true
-        default: "dev-v2.15"
+        default: "dev-v2.16"
       prev_remotedialer:
         description: "Previous remotedialer version (eg: v0.8.0-rc.1)"
         required: true

--- a/VERSION.md
+++ b/VERSION.md
@@ -2,7 +2,8 @@ Rancher's remotedialer-proxy follows a pre-release (v0.x) strategy of semver. Th
 
 | remotedialer-proxy Branch | remotedialer-proxy Minor version | Rancher Minor Version |
 |---------------------------|-----------------------------------|----------------------|
-| main | v0.8 | v2.15 |
+| main | v0.9 | v2.16 |
+| release/v0.8 | v0.8 | v2.15 |
 | release/v0.7 | v0.7 | v2.14 |
 | release/v0.6 | v0.6 | v2.13 |
 | release/v0.5 | v0.5 | v2.12 |


### PR DESCRIPTION
Following rancher/rancher branching for v2.15 (release/v2.15), branch out remotedialer-proxy and advance main to the next minor.

- `.github/renovate.json`: add `release/v0.8` to `baseBranchPatterns` (existing branches kept).
- `VERSION.md`: main → v0.9 (Rancher v2.16); record release/v0.8 (Rancher v2.15).
- `.github/workflows/release-charts.yaml`: `charts_ref` default `dev-v2.15` → `dev-v2.16`.

Part of the release/v0.8 branch-out. A separate PR pins the CI workflow rancher refs on release/v0.8.