### PR TITLE
Pin CI workflows to Rancher release/v2.15 on release/v0.8

### DIFF
--- a/.github/workflows/release-rancher.yaml
+++ b/.github/workflows/release-rancher.yaml
@@ -5,7 +5,7 @@ on:
       rancher_ref:
         description: "Submit PR against the following rancher/rancher branch (eg: main)"
         required: true
-        default: "main"
+        default: "release/v2.15"
       prev_remotedialer:
         description: "Previous remotedialer-proxy version (eg: v0.2.0-rc.1)"
         required: true

--- a/.github/workflows/sync-deps.yaml
+++ b/.github/workflows/sync-deps.yaml
@@ -6,7 +6,7 @@ on:
       rancher_ref:
         description: "Version of rancher/rancher to compare"
         required: true
-        default: "main"
+        default: "release/v2.15"
       rancher_repository:
         description: "Repository for rancher/rancher"
         required: true


### PR DESCRIPTION
On the new `release/v0.8` branch (Rancher v2.15), pin the workflow `rancher_ref` defaults so dispatched runs target the matching Rancher release line instead of `main`.

- `.github/workflows/release-rancher.yaml`: `rancher_ref` default `main` → `release/v2.15`.
- `.github/workflows/sync-deps.yaml`: `rancher_ref` default `main` → `release/v2.15`.

Part of the release/v0.8 branch-out.