### PR TITLE
[main] update go dependency when bumping chart version

### DIFF
--- a/.github/workflows/scripts/release-against-rancher.sh
+++ b/.github/workflows/scripts/release-against-rancher.sh
@@ -85,6 +85,12 @@ yq --inplace ".remoteDialerProxyVersion = \"${NEW_CHART_VERSION}+up${NEW_REMOTED
 go generate ./...
 
 git add .
-git commit -m "Bump remotedialer to ${NEW_CHART_VERSION}+up${NEW_REMOTEDIALER_VERSION_SHORT}"
+git commit -m "Bump remotedialer chart to ${NEW_CHART_VERSION}+up${NEW_REMOTEDIALER_VERSION_SHORT}"
+
+go get github.com/rancher/remotedialer-proxy@${NEW_REMOTEDIALER_VERSION}
+go mod tidy
+
+git add .
+git commit -m "Bump remotedialer to ${NEW_REMOTEDIALER_VERSION}"
 
 popd > /dev/null


### PR DESCRIPTION
Updates the dependency in `go.mod` as well to ensure we do not forget to do so.