### PR TITLE
Migrate renovate config to per-release-line presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,23 +20,37 @@
   ],
   "packageRules": [
     {
+      "matchBaseBranches": ["main"],
+      "extends": ["github>rancher/renovate-config:rancher-main#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.8"],
+      "extends": ["github>rancher/renovate-config:rancher-2.15#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.7"],
+      "extends": ["github>rancher/renovate-config:rancher-2.14#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.6"],
+      "extends": ["github>rancher/renovate-config:rancher-2.13#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.5"],
+      "extends": ["github>rancher/renovate-config:rancher-2.12#main"]
+    },
+    {
+      "matchBaseBranches": ["release/v0.4"],
+      "extends": ["github>rancher/renovate-config:rancher-2.11#main"]
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
-        "/k8s.io/*/",
-        "/sigs.k8s.io/*/",
         "/github.com/prometheus/*/",
         "github.com/rancher/wrangler/v3",
         "github.com/rancher/dynamiclistener",
         "github.com/rancher/remotedialer"
       ]
-    },
-    {
-      "matchUpdateTypes": ["patch"],
-      "matchPackageNames": [
-        "/k8s.io/*/",
-        "/sigs.k8s.io/*/"
-      ],
-      "enabled": true
     },
     {
       "matchPackageNames": ["golang"],


### PR DESCRIPTION
Replaces the repo-local k8s.io/sigs.k8s.io version-pin `packageRules` with per-branch `extends` of `rancher/renovate-config`'s per-release-line presets, per rancher/rancher#50186.
