### PR TITLE
[release/v0.8] Fix HELM_CHECKSUM_amd64 for helm v4.2.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           # renovate: datasource=github-release-attachments depName=helm/helm
           HELM_VERSION: v4.2.3
           # renovate: datasource=github-release-attachments depName=helm/helm digestVersion=v4.2.3
-          HELM_CHECKSUM_amd64: 97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096
+          HELM_CHECKSUM_amd64: e9b88b4ee95b18c706839c28d3a0220e5bc470e9cd9262410c90793c45ff8b7c
         run: |
           curl -sLO https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
           echo "${HELM_CHECKSUM_amd64}  helm-${HELM_VERSION}-linux-amd64.tar.gz" | sha256sum -c -


### PR DESCRIPTION
- PR #213 bumped HELM_VERSION to v4.2.3 but left HELM_CHECKSUM_amd64 pointing at the v4.2.0 checksum (same issue as #222 on main, fixed in #229)
- Update checksum to correct sha256 for helm-v4.2.3-linux-amd64.tar.gz